### PR TITLE
Carlos dev tmp

### DIFF
--- a/src/main/java/de/tum/bgu/msm/longDistance/data/trips/AccessEgressMode.java
+++ b/src/main/java/de/tum/bgu/msm/longDistance/data/trips/AccessEgressMode.java
@@ -1,0 +1,9 @@
+package de.tum.bgu.msm.longDistance.data.trips;
+
+public enum AccessEgressMode {
+
+    AUTO_ACCESS,
+    WALK_ACCESS,
+    PUBLIC_TRANSPORT_ACCESS,
+    SHUTTLE_ACCESS;
+}

--- a/src/main/java/de/tum/bgu/msm/longDistance/data/trips/LongDistanceTripGermany.java
+++ b/src/main/java/de/tum/bgu/msm/longDistance/data/trips/LongDistanceTripGermany.java
@@ -28,6 +28,8 @@ public class LongDistanceTripGermany implements LongDistanceTrip {
     private ZoneTypeGermany destZoneType;
     private Zone destZone;
     private Mode travelMode;
+    private AccessEgressMode accessMode;
+    private Mode egressMode;
     private float autoTravelDistance = -1;
     private float autoTravelTime = -1;
     private float distanceByMode = -1;
@@ -193,6 +195,22 @@ public class LongDistanceTripGermany implements LongDistanceTrip {
 
     public void setDestY(double destY) {
         this.destY = destY;
+    }
+
+    public AccessEgressMode getAccessMode() {
+        return accessMode;
+    }
+
+    public void setAccessMode(AccessEgressMode accessMode) {
+        this.accessMode = accessMode;
+    }
+
+    public Mode getEgressMode() {
+        return egressMode;
+    }
+
+    public void setEgressMode(Mode egressMode) {
+        this.egressMode = egressMode;
     }
 
     public static String getHeader() {

--- a/src/main/java/de/tum/bgu/msm/longDistance/io/reader/SkimsReaderGermany.java
+++ b/src/main/java/de/tum/bgu/msm/longDistance/io/reader/SkimsReaderGermany.java
@@ -215,9 +215,9 @@ public class SkimsReaderGermany implements SkimsReader {
         List<Matrix> matricesBus = new ArrayList<>();
         matricesBus.add(omxToMatrix(inPtTimeFileNames.get(m), "travel_time_s", lookUps.get(m)));
         time = logReading(time, "bus time");
-        matricesBus.add(omxToMatrix(accessTimeFileNames.get(m), "access_time_s", lookUps.get(m)));
+        //matricesBus.add(omxToMatrix(accessTimeFileNames.get(m), "access_time_s", lookUps.get(m)));
         time = logReading(time, "bus access");
-        matricesBus.add(omxToMatrix(egressTimeFileNames.get(m), "egress_time_s", lookUps.get(m)));
+        //matricesBus.add(omxToMatrix(egressTimeFileNames.get(m), "egress_time_s", lookUps.get(m)));
         time = logReading(time, "bus egress");
         Matrix totalTravelTimeBus = sumMatrices(matricesBus);
         Matrix distanceBus = omxToMatrix(distanceFileNames.get(m), distanceMatrixNames.get(m), lookUps.get(m));
@@ -233,9 +233,10 @@ public class SkimsReaderGermany implements SkimsReader {
         List<Matrix> matricesRail = new ArrayList<>();
         matricesRail.add(omxToMatrix(inPtTimeFileNames.get(m), "travel_time_s", lookUps.get(m)));
         time = logReading(time, "rail time");
-        matricesRail.add(omxToMatrix(accessTimeFileNames.get(m), "access_time_s", lookUps.get(m)));
+        Matrix accessTimeRailMatrix = omxToMatrix(accessTimeFileNames.get(m), "access_time_s", lookUps.get(m));
+        //matricesRail.add(accessTimeRailMatrix);
         time = logReading(time, "rail access");
-        matricesRail.add(omxToMatrix(egressTimeFileNames.get(m), "egress_time_s", lookUps.get(m)));
+        //matricesRail.add(omxToMatrix(egressTimeFileNames.get(m), "egress_time_s", lookUps.get(m)));
         time = logReading(time, "rail egress");
         Matrix totalTravelTimeRail = sumMatrices(matricesRail);
         Matrix distanceRail = omxToMatrix(distanceFileNames.get(m), distanceMatrixNames.get(m), lookUps.get(m));
@@ -248,7 +249,7 @@ public class SkimsReaderGermany implements SkimsReader {
         modeDistanceMatrixMap.put(m, modeMatrixMap.get("distance"));
 
         // added the access time of each zone to ld rail station
-        readTimeToRail(matricesRail.get(1), dataSet, 5, 10*60, 1);
+        readTimeToRail(accessTimeRailMatrix, dataSet, 5, 10*60, 1);
         time = logReading(time, "access to train");
 
         dataSet.setTravelTimeMatrix(modeTimeMatrixMap);
@@ -368,7 +369,7 @@ public class SkimsReaderGermany implements SkimsReader {
             double[] minDistValues = new double[numberOfNeighbours];
             for (int k = 0; k < numberOfNeighbours; k++) {
                 minTimeValues[k] = maximumSeconds;
-                minDistValues[k] = maximumSeconds / 60 * speed; //maximum distance results from maximum time at 50 km/h
+                minDistValues[k] = maximumSeconds * speed / 3.6; //maximum distance (in m)results from maximum time at speed in km/h
             }
             //find the  n closest neighbors - the lower travel time values in the matrix column
             for (int j = 0; j < travelTimeMatrix.getRowCount(); j++) {

--- a/src/main/java/de/tum/bgu/msm/longDistance/modeChoice/DomesticModeChoiceGermany.java
+++ b/src/main/java/de/tum/bgu/msm/longDistance/modeChoice/DomesticModeChoiceGermany.java
@@ -143,10 +143,6 @@ public class DomesticModeChoiceGermany {
                     time = time + dataSet.getTransferTimeAirport().get(legs.get(0).getDestination());
                 }
                 time = time + dataSet.getBoardingTime_sec() + dataSet.getPostprocessTime_sec();
-                //time = time + dataSet.getTravelTimeMatrix().get(ModeGermany.AUTO).getValueAt(origin, originAirport.getId());
-                //time = time + dataSet.getTravelTimeMatrix().get(ModeGermany.AUTO).getValueAt(destinationAirport.getId(), destination);
-                //distanceAccessEgress = distanceAccessEgress + dataSet.getDistanceMatrix().get(ModeGermany.AUTO).getValueAt(origin, originAirport.getId());
-                //distanceAccessEgress = distanceAccessEgress + dataSet.getDistanceMatrix().get(ModeGermany.AUTO).getValueAt(destinationAirport.getId(), destination);
                 dataSet.getTravelTimeMatrix().get(m).setValueAt(origin, destination, (float) time);
                 time = time / 3600;
                 distance = distance / 1000;

--- a/src/main/java/de/tum/bgu/msm/longDistance/modeChoice/DomesticModeChoiceGermany.java
+++ b/src/main/java/de/tum/bgu/msm/longDistance/modeChoice/DomesticModeChoiceGermany.java
@@ -83,19 +83,19 @@ public class DomesticModeChoiceGermany {
 
             //calculate exp(Ui) for each destination
             expUtilities = Arrays.stream(ModeGermany.values()).mapToDouble(m -> Math.exp(calculateUtilityFromGermany(trip, m))).toArray();
-
             double probability_denominator = Arrays.stream(expUtilities).sum();
 
             attributes = ((LongDistanceTripGermany) t).getAdditionalAttributes();
-
             //if there is no access by any mode for the selected OD pair, just go by car
-            if (probability_denominator != 0) {
-
+            if (probability_denominator != 0 && !Double.isNaN(probability_denominator)) {
                 for (int mode = 0; mode < expUtilities.length; mode++) {
                     attributes.put("utility_" + ModeGermany.getMode(mode), (float) (expUtilities[mode] / probability_denominator));
                 }
-            }else{
+            } else {
                 expUtilities[0] = 1;
+                expUtilities[1] = 0;
+                expUtilities[2] = 0;
+                expUtilities[3] = 0;
                 for (int mode = 0; mode < expUtilities.length; mode++) {
                     attributes.put("utility_" + ModeGermany.getMode(mode), (float) expUtilities[mode]);
                 }
@@ -157,9 +157,16 @@ public class DomesticModeChoiceGermany {
         }
         if (time < 1000000000 / 3600){
             if (vot != 0) {
-                double cost = costsPerKm.getStringIndexedValueAt("alpha", m.toString()) *
-                        Math.pow(distance, costsPerKm.getStringIndexedValueAt("beta", m.toString()) )
-                        * distance;
+                double cost;
+                if(distance != 0){
+                    cost = costsPerKm.getStringIndexedValueAt("alpha", m.toString()) *
+                            Math.pow(distance, costsPerKm.getStringIndexedValueAt("beta", m.toString()))
+                            * distance;
+                } else {
+                    //todo technically the distance and cost cannot be zero. However, this happens when there is no segment by main mode (only access + egress)
+                    cost = 0;
+                }
+
                 //if (m.equals(ModeGermany.AIR)) {
                 //    float increaseAirCost = dataSet.getScenarioSettings().getValueAt(dataSet.getScenario(),"cost");
                 //    cost = cost * increaseAirCost;


### PR DESCRIPTION
- Solves a bug in trips with distances on main mode equal to zero (the cost should be zero, at least, as far as access and egress trip costs are not considered explicitely). 
- Avoids reading access and egress times, as they are included already in the total time matrices.
- Solves a minor bug in the conversion of units in the assignment of intrazonal distances. 